### PR TITLE
Do not render tweets anymore if it is the last page regardless

### DIFF
--- a/twitter_analysis.py
+++ b/twitter_analysis.py
@@ -117,5 +117,9 @@ def get_tweets(user, tweets=None, retweets=False, notext=False, adddot=True, max
                 last_tweet = html.find('.stream-item')[-1].attrs['data-item-id']
                 r = session.get(url, params={'max_position': last_tweet}, headers=headers)
                 pages += -1
+            else:
+                # reset the count regardless since there are no more tweets left
+                found = 0
+
 
     yield from gen_tweets(tweets, retweets, notext, adddot, maxpages)


### PR DESCRIPTION
Hello again. This is really an edge case, but apparently when you specify the number of tweets that is more than the tweets of that account, due to my last code #6 it would also still return an incorrect number of tweets. Example:

```python
get_tweets('manyver_se', tweets=50)
# this will give you 50 tweets, among which are duplicated tweets
# because the account has < 50 tweets
```

I figured that the count should be reset to avoid returning duplicated the tweets to match the specified `tweets` number.

Also, any chance of releasing the new version of the package soon? Many thanks!
